### PR TITLE
Move the operator subscriptions into it's own file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# OKD Virtualization CI
+# OKD Virtualization
+
 [![Build Status](https://prow.ci.openshift.org/badge.svg?jobs=periodic-ci-okd-virtualization-ci-master-okd-e2e-deploy)](https://prow.ci.openshift.org/job-history/gs/origin-ci-test/logs/periodic-ci-okd-virtualization-ci-master-okd-e2e-deploy)
 
 # Testing the integration between

--- a/hack/deploy-hco.sh
+++ b/hack/deploy-hco.sh
@@ -19,53 +19,9 @@ trap "cleanup" INT TERM EXIT
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-echo "creating catalogsource"
-cat <<EOF | oc apply -f -
-apiVersion: operators.coreos.com/v1alpha1
-kind: CatalogSource
-metadata:
-  name: hco-unstable-catalog-source
-  namespace: openshift-marketplace
-spec:
-  sourceType: grpc
-  image: quay.io/kubevirt/hyperconverged-cluster-index:${HCO_RELEASE}-unstable
-  displayName: Kubevirt Hyperconverged Cluster Operator
-  publisher: Kubevirt Project
-EOF
-
-echo "creating namespace"
-cat <<EOF | oc apply -f -
-apiVersion: v1
-kind: Namespace
-metadata:
-    name: ${TARGET_NAMESPACE}
-EOF
-
-echo "creating operator group"
-cat <<EOF | oc apply -f -
-apiVersion: operators.coreos.com/v1
-kind: OperatorGroup
-metadata:
-    name: kubevirt-hyperconverged-group
-    namespace: ${TARGET_NAMESPACE}
-EOF
-
-echo "creating subscription"
-oc create -f - <<EOF
-apiVersion: operators.coreos.com/v1alpha1
-kind: Subscription
-metadata:
-  name: kubevirt-hyperconverged
-  namespace: "${TARGET_NAMESPACE}"
-  labels:
-    operators.coreos.com/kubevirt-hyperconverged.kubevirt-hyperconverged: ''
-spec:
-  channel: ${HCO_RELEASE}
-  installPlanApproval: Automatic
-  name: community-kubevirt-hyperconverged
-  source: hco-unstable-catalog-source
-  sourceNamespace: openshift-marketplace
-EOF
+echo "creating catalogsource, operator group, and subscription"
+oc create namespace ${TARGET_NAMESPACE}
+oc apply -n ${TARGET_NAMESPACE} -f ${SCRIPT_DIR}/../manifests/virtualization.yaml
 
 echo "waiting for HyperConverged operator to become ready"
 "$SCRIPT_DIR"/wait-for-hco.sh

--- a/hack/deploy-hco.sh
+++ b/hack/deploy-hco.sh
@@ -21,6 +21,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 echo "creating catalogsource, operator group, and subscription"
 oc create namespace ${TARGET_NAMESPACE}
+oc apply -f ${SCRIPT_DIR}/../manifests/catalog-unstable.yaml
 oc apply -n ${TARGET_NAMESPACE} -f ${SCRIPT_DIR}/../manifests/virtualization.yaml
 
 echo "waiting for HyperConverged operator to become ready"

--- a/manifests/catalog-unstable.yaml
+++ b/manifests/catalog-unstable.yaml
@@ -1,0 +1,14 @@
+#
+# Manifest to enable the HCO catalog
+#
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: hco-unstable-catalog-source
+  namespace: openshift-marketplace
+spec:
+  sourceType: grpc
+  image: quay.io/kubevirt/hyperconverged-cluster-index:1.6.0-unstable
+  displayName: Kubevirt Hyperconverged Cluster Operator
+  publisher: Kubevirt Project
+

--- a/manifests/virtualization.yaml
+++ b/manifests/virtualization.yaml
@@ -1,14 +1,6 @@
-apiVersion: operators.coreos.com/v1alpha1
-kind: CatalogSource
-metadata:
-  name: hco-unstable-catalog-source
-  namespace: openshift-marketplace
-spec:
-  sourceType: grpc
-  image: quay.io/kubevirt/hyperconverged-cluster-index:1.6.0-unstable
-  displayName: Kubevirt Hyperconverged Cluster Operator
-  publisher: Kubevirt Project
----
+#
+# Manifest to subscribe to the HCO operator
+#
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:

--- a/manifests/virtualization.yaml
+++ b/manifests/virtualization.yaml
@@ -1,0 +1,28 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: hco-unstable-catalog-source
+  namespace: openshift-marketplace
+spec:
+  sourceType: grpc
+  image: quay.io/kubevirt/hyperconverged-cluster-index:1.6.0-unstable
+  displayName: Kubevirt Hyperconverged Cluster Operator
+  publisher: Kubevirt Project
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+    name: kubevirt-hyperconverged-group
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: kubevirt-hyperconverged
+  labels:
+    operators.coreos.com/kubevirt-hyperconverged.kubevirt-hyperconverged: ''
+spec:
+  channel: 1.6.0
+  installPlanApproval: Automatic
+  name: community-kubevirt-hyperconverged
+  source: hco-unstable-catalog-source
+  sourceNamespace: openshift-marketplace


### PR DESCRIPTION
The idea is to separate the essential parts of deploying the virtualization specific operatos into it's own file.
Once this is stable, this can become a release artifact.

Signed-off-by: Fabian Deutsch <fabiand@fedoraproject.org>